### PR TITLE
Brandon test transport fixups: Use python3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
             echo "Branch starts with dev or release, or tagged commit starts with v. Optimized build"
             make ci-binary
           else
-            echo "Non-release branch, non-optimized build with coverage"
-            BUILD_FLAGS="--fast --coverage" make ci-binary
+            echo "Non-release branch, build with coverage"
+            BUILD_FLAGS="--coverage" make ci-binary
           fi
     - run:
         name: Build the docker image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,8 @@ jobs:
   # build the server binary, and package into docker image
   build_server:
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - &server_builder_image
+      image: hasura/graphql-engine-server-builder:20191031
     working_directory: ~/graphql-engine
     steps:
     - attach_workspace:
@@ -222,7 +223,7 @@ jobs:
     environment:
       PG_VERSION: "12"
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - *server_builder_image
     - image: circleci/postgres:12-alpine-postgis
       <<: *test_pg_env
  
@@ -231,7 +232,7 @@ jobs:
     environment:
       PG_VERSION: "11"
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - *server_builder_image
     - image: circleci/postgres:10-alpine-postgis
       <<: *test_pg_env
 
@@ -240,7 +241,7 @@ jobs:
     environment:
       PG_VERSION: "10"
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - *server_builder_image
     - image: circleci/postgres:10-alpine-postgis
       <<: *test_pg_env
 
@@ -249,7 +250,7 @@ jobs:
     environment:
       PG_VERSION: "9_6"
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - *server_builder_image
     - image: circleci/postgres:9.6-alpine-postgis
       <<: *test_pg_env
 
@@ -258,7 +259,7 @@ jobs:
     environment:
       PG_VERSION: "9_5"
     docker:
-    - image: hasura/graphql-engine-server-builder:20190826
+    - *server_builder_image
     - image: circleci/postgres:9.5-alpine-postgis
       <<: *test_pg_env
 

--- a/.circleci/server-builder.dockerfile
+++ b/.circleci/server-builder.dockerfile
@@ -9,7 +9,7 @@ ARG postgres_ver="11"
 
 # Install GNU make, curl, git and docker client. Required to build the server
 RUN apt-get -y update \
-    && apt-get -y install curl gnupg2 cmake pkgconf \
+    && apt-get -y install curl gnupg2 cmake pkgconf sudo \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get -y update \
@@ -19,6 +19,19 @@ RUN apt-get -y update \
     && mv /tmp/docker/* /usr/bin \
     && git clone https://github.com/google/brotli.git && cd brotli && mkdir out && cd out && ../configure-cmake \
     && make && make test && make install && ldconfig \
+    # Install Python 3.7.4 \
+    && apt-get install -y build-essential checkinstall \
+    && apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev \
+         libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev \
+    && curl -O https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz \
+    && tar -xf Python-3.7.4.tar.xz \
+    && cd Python-3.7.4 \
+    && ./configure --enable-optimizations \
+    && make -j 4 \
+    && make altinstall \
+    && python3.7 --version \
+    && rm -rf Python-3.7.4 Python-3.7.4.tar.xz \
+    # Install stack \
     && curl -sL https://github.com/commercialhaskell/stack/releases/download/v${stack_ver}/stack-${stack_ver}-linux-x86_64.tar.gz \
        | tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack' \
     && stack --resolver ${resolver} setup \

--- a/.circleci/test-server.sh
+++ b/.circleci/test-server.sh
@@ -123,6 +123,8 @@ start_multiple_hge_servers() {
 	wait_for_port 8080
 }
 
+PYTHON=python3.7
+PYTEST="$PYTHON -m pytest"
 
 if [ -z "${HASURA_GRAPHQL_DATABASE_URL:-}" ] ; then
 	echo "Env var HASURA_GRAPHQL_DATABASE_URL is not set"
@@ -184,7 +186,7 @@ done
 echo -e "\nINFO: GraphQL Executable : $GRAPHQL_ENGINE"
 echo -e "INFO: Logs Folder        : $OUTPUT_FOLDER\n"
 
-pip3 install -r requirements.txt
+$PYTHON -m pip install -r requirements.txt
 
 mkdir -p "$OUTPUT_FOLDER/hpc"
 
@@ -209,11 +211,11 @@ run_pytest_parallel() {
 	trap stop_services ERR
 	if [ -n ${HASURA_GRAPHQL_DATABASE_URL_2:-} ] ; then
 		set -x
-		pytest -vv --hge-urls "$HGE_URL" "${HGE_URL_2:-}" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" "${HASURA_GRAPHQL_DATABASE_URL_2:-}" -n 2 --dist=loadfile "$@"
+		$PYTEST -vv --hge-urls "$HGE_URL" "${HGE_URL_2:-}" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" "${HASURA_GRAPHQL_DATABASE_URL_2:-}" -n 2 --dist=loadfile "$@"
 		set +x
 	else
 		set -x
-		pytest -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" -n 1 "$@"
+		$PYTEST -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" -n 1 "$@"
 		set +x
 	fi
 }
@@ -267,7 +269,7 @@ export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jw
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
 
 kill_hge_servers
 
@@ -282,7 +284,7 @@ export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jw
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
 
 kill_hge_servers
 
@@ -296,7 +298,7 @@ export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jw
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
 
 kill_hge_servers
 
@@ -310,7 +312,7 @@ export HASURA_GRAPHQL_JWT_SECRET="$(jq -n --arg key "$(cat $OUTPUT_FOLDER/ssl/jw
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-jwt-key-file="$OUTPUT_FOLDER/ssl/jwt_private.key" --hge-jwt-conf="$HASURA_GRAPHQL_JWT_SECRET" test_jwt.py
 
 kill_hge_servers
 
@@ -326,7 +328,7 @@ TEST_TYPE="cors-domains"
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n  1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-cors test_cors.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-cors test_cors.py
 
 kill_hge_servers
 
@@ -347,7 +349,7 @@ run_hge_with_args serve
 wait_for_port 8080
 
 echo "$(time_elapsed): testcase 1: read cookie, cors enabled"
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=read test_websocket_init_cookie.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=read test_websocket_init_cookie.py
 
 kill_hge_servers
 
@@ -357,7 +359,7 @@ run_hge_with_args serve --disable-cors
 
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=noread test_websocket_init_cookie.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=noread test_websocket_init_cookie.py
 
 kill_hge_servers
 
@@ -367,7 +369,7 @@ export HASURA_GRAPHQL_WS_READ_COOKIE="true"
 run_hge_with_args serve --disable-cors
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=read test_websocket_init_cookie.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-ws-init-cookie=read test_websocket_init_cookie.py
 
 kill_hge_servers
 
@@ -384,7 +386,7 @@ export HASURA_GRAPHQL_ENABLED_APIS="metadata"
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-graphql-disabled test_apis_disabled.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-graphql-disabled test_apis_disabled.py
 
 kill_hge_servers
 
@@ -393,7 +395,7 @@ unset HASURA_GRAPHQL_ENABLED_APIS
 run_hge_with_args serve --enabled-apis metadata
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-graphql-disabled test_apis_disabled.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-graphql-disabled test_apis_disabled.py
 
 kill_hge_servers
 
@@ -405,7 +407,7 @@ export HASURA_GRAPHQL_ENABLED_APIS="graphql"
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-metadata-disabled test_apis_disabled.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-metadata-disabled test_apis_disabled.py
 
 kill_hge_servers
 unset HASURA_GRAPHQL_ENABLED_APIS
@@ -413,7 +415,7 @@ unset HASURA_GRAPHQL_ENABLED_APIS
 run_hge_with_args serve --enabled-apis graphql
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-metadata-disabled test_apis_disabled.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-metadata-disabled test_apis_disabled.py
 
 kill_hge_servers
 
@@ -423,7 +425,7 @@ TEST_TYPE="query-caching"
 # use only one capability to disable cache striping
 run_hge_with_args +RTS -N1 -RTS serve
 wait_for_port 8080
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" test_graphql_queries.py::TestGraphQLQueryCaching
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" test_graphql_queries.py::TestGraphQLQueryCaching
 kill_hge_servers
 
 # verbose logging tests
@@ -445,7 +447,7 @@ set +x
 
 wait_for_port 8080
 
-pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-logging test_logging.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-logging test_logging.py
 
 unset HASURA_GRAPHQL_ENABLED_LOG_TYPES
 kill_hge_servers
@@ -498,7 +500,7 @@ if [ "$RUN_WEBHOOK_TESTS" == "true" ] ; then
 
 	wait_for_port 8080
 
-	pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-webhook="$HASURA_GRAPHQL_AUTH_HOOK" --test-webhook-insecure test_webhook_insecure.py
+	$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-webhook="$HASURA_GRAPHQL_AUTH_HOOK" --test-webhook-insecure test_webhook_insecure.py
 
 	kill_hge_servers
 
@@ -510,7 +512,7 @@ if [ "$RUN_WEBHOOK_TESTS" == "true" ] ; then
 
 	wait_for_port 8080
 
-	pytest -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-webhook="$HASURA_GRAPHQL_AUTH_HOOK" --test-webhook-insecure test_webhook_insecure.py
+	$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --hge-webhook="$HASURA_GRAPHQL_AUTH_HOOK" --test-webhook-insecure test_webhook_insecure.py
 
 	kill_hge_servers
 
@@ -531,7 +533,7 @@ TEST_TYPE="allowlist-queries"
 run_hge_with_args serve
 wait_for_port 8080
 
-pytest -n  1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-allowlist-queries test_allowlist_queries.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-allowlist-queries test_allowlist_queries.py
 
 kill_hge_servers
 unset HASURA_GRAPHQL_ENABLE_ALLOWLIST
@@ -539,7 +541,7 @@ unset HASURA_GRAPHQL_ENABLE_ALLOWLIST
 run_hge_with_args serve --enable-allowlist
 wait_for_port 8080
 
-pytest -n  1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-allowlist-queries test_allowlist_queries.py
+$PYTEST -n 1 -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --hge-key="$HASURA_GRAPHQL_ADMIN_SECRET" --test-allowlist-queries test_allowlist_queries.py
 
 kill_hge_servers
 
@@ -605,7 +607,7 @@ run_hge_with_args --database-url "$HASURA_HS_TEST_DB" serve \
 wait_for_port 8081
 
 # run test
-pytest -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --test-hge-scale-url="http://localhost:8081" test_horizontal_scale.py
+$PYTEST -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --test-hge-scale-url="http://localhost:8081" test_horizontal_scale.py
 
 # Shutdown pgbouncer
 psql "postgres://postgres:postgres@localhost:6543/pgbouncer" -c "SHUTDOWN;" || true
@@ -621,7 +623,7 @@ cd $PYTEST_ROOT
 sleep 20
 
 # run test
-pytest -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --test-hge-scale-url="http://localhost:8081" test_horizontal_scale.py
+$PYTEST -vv --hge-urls "$HGE_URL" --pg-urls "$HASURA_GRAPHQL_DATABASE_URL" --test-hge-scale-url="http://localhost:8081" test_horizontal_scale.py
 
 # Shutdown pgbouncer
 psql "postgres://postgres:postgres@localhost:6543/pgbouncer" -c "SHUTDOWN;" || true

--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v0.4.7"
 
 [[projects]]
+  branch = "master"
+  digest = "1:67f5c19d64f788aa79a8e612eefa1cc68dca46c3436c93b84af9c95bd7e1a556"
+  name = "github.com/aryann/difflib"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e206f873d14a916d3d26c40ab667bca123f365a3"
+
+[[projects]]
   digest = "1:889290ee5c1f1888baa7caa2b4cdfa8a6abcfb86dd772fe6470ad7925cc44bff"
   name = "github.com/briandowns/spinner"
   packages = ["."]
@@ -299,6 +307,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2b32af4d2a529083275afc192d1067d8126b578c7a9613b26600e4df9c735155"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
+
+[[projects]]
+  branch = "master"
   digest = "1:8eb17c2ec4df79193ae65b621cd1c0c4697db3bc317fe6afdc76d7f2746abd05"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
@@ -535,6 +551,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/aryann/difflib",
     "github.com/briandowns/spinner",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/container",
@@ -553,6 +570,7 @@
     "github.com/lib/pq",
     "github.com/manifoldco/promptui",
     "github.com/mattn/go-colorable",
+    "github.com/mgutz/ansi",
     "github.com/mitchellh/go-homedir",
     "github.com/oliveagle/jsonpath",
     "github.com/parnurzeal/gorequest",
@@ -562,6 +580,7 @@
     "github.com/skratchdot/open-golang/open",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
+    "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
   ]

--- a/cli/Gopkg.lock
+++ b/cli/Gopkg.lock
@@ -18,6 +18,22 @@
   version = "v0.4.7"
 
 [[projects]]
+  digest = "1:31bd9d70492aec37a6bf45a42e96ed0f37fab74aa619d539b5acb9477500eb79"
+  name = "github.com/ahmetb/go-linq"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b1b02a14bd27fab06f03ca1e4eed893f5011c152"
+  version = "v3.1.0"
+
+[[projects]]
+  digest = "1:320e7ead93de9fd2b0e59b50fd92a4d50c1f8ab455d96bc2eb083267453a9709"
+  name = "github.com/asaskevich/govalidator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
+  version = "v9"
+  
+[[projects]]
   branch = "master"
   digest = "1:67f5c19d64f788aa79a8e612eefa1cc68dca46c3436c93b84af9c95bd7e1a556"
   name = "github.com/aryann/difflib"
@@ -205,6 +221,38 @@
   revision = "5a0f697c9ed9d68fef0116532c6e05cfeae00e55"
 
 [[projects]]
+  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:e72d1ebb8d395cf9f346fd9cbc652e5ae222dd85e0ac842dc57f175abed6d195"
+  name = "github.com/gorilla/securecookie"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e59506cc896acb7f7bf732d4fdf5e25f7ccd8983"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:172c862eabc72e90f461bcef223c49869628bec6d989386dfb03281ae3222148"
+  name = "github.com/gorilla/sessions"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4355a998706e83fe1d71c31b07af94e34f68d74a"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:17275ec8407e731ae22cc511d52391b2ac31982f23b53b1100265c575dc5cc9f"
+  name = "github.com/gosimple/slug"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "984b6d1a0ae5d1ecf6d718f4e990883d281ba3b8"
+  version = "v1.7.0"
+
+[[projects]]
   branch = "master"
   digest = "1:a361611b8c8c75a1091f00027767f7779b29cb37c456a71b8f2604c88057ab40"
   name = "github.com/hashicorp/hcl"
@@ -232,6 +280,30 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:0ba2632215132e946413632241c2f9e67439addbe5f243b86bb81199bd15c8e9"
+  name = "github.com/jinzhu/gorm"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "81c17a7e2529c59efc4e74c5b32c1fb71fb12fa2"
+  version = "v1.9.11"
+
+[[projects]]
+  digest = "1:01ed62f8f4f574d8aff1d88caee113700a2b44c42351943fa73cc1808f736a50"
+  name = "github.com/jinzhu/inflection"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f5c5f50e6090ae76a29240b61ae2a90dd810112e"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:e668ebc4cec3a084c222b4255a1565ee652614f029a7b2f4b1bc9557565ed473"
+  name = "github.com/jinzhu/now"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1a6fdd4591d336a897120c50c69ed3c0e8033468"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:e51f40f0c19b39c1825eadd07d5c0a98a2ad5942b166d9fc4f54750ce9a04810"
   name = "github.com/juju/ansiterm"
@@ -249,6 +321,22 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
+
+[[projects]]
+  digest = "1:ca955a9cd5b50b0f43d2cc3aeb35c951473eeca41b34eb67507f1dbcc0542394"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:15b5cc79aad436d47019f814fde81a10221c740dc8ddf769221a65097fb6c2e9"
+  name = "github.com/kr/text"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
@@ -304,6 +392,14 @@
   pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
+
+[[projects]]
+  digest = "1:6ff1026b8d873d074ddec82ad60bb0eb537dc013f456ef26b63d30beba2f99e7"
+  name = "github.com/microcosm-cc/bluemonday"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "506f3da9b7c86d737e91f16b7431df8635871552"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
@@ -376,6 +472,102 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:88dfda28c9738dd59becb9bbc449120ecef8b1d54e32e6004654bb66e51ef897"
+  name = "github.com/qor/admin"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b2f472167d028a04c736b4a2477d7cce1e578b8f"
+  version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d2bdad175842f83799e02819fa718858ebde6f8704101a7dfa0a4a8e8742e587"
+  name = "github.com/qor/assetfs"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ff57fdc13a148d39c3e930cb27c7eaf82e376891"
+
+[[projects]]
+  digest = "1:810e030da1090675a7f04c88e6de987dfc8cf1236d502dd0b5fb63cd6cc58481"
+  name = "github.com/qor/audited"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b52c9c2f0571fc6e56dcdf2b7d3ae36d124602d4"
+  version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d221e9b7e68759e27735dd1929cc37c916eb814cc5ef5bacf533d47d1ca55ff1"
+  name = "github.com/qor/middlewares"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "781378b69454a545d08058d8154aca40d079e7ab"
+
+[[projects]]
+  digest = "1:7f19097491f6d7e42cf4babafbfbbdb4ed20985a1bbb2c2efa2e98dfa4eee696"
+  name = "github.com/qor/qor"
+  packages = [
+    ".",
+    "resource",
+    "utils",
+  ]
+  pruneopts = "UT"
+  revision = "186b0237364b23ebbe564d0764c5b8523c953575"
+  version = "v1.1"
+
+[[projects]]
+  digest = "1:1b90231d81fce4a2c61be9bbae0e6cc35556ab7bf87e574e9dc334a1985125df"
+  name = "github.com/qor/responder"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b6def473574f621fee316696ad120d4fbf470826"
+  version = "v1.1"
+
+[[projects]]
+  digest = "1:be8425925ff99bd3fb026add07beb8069fed5c8e199b1cd55a871f832d9f6688"
+  name = "github.com/qor/roles"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d6375609fe3e5da46ad3a574fae244fb633e79c1"
+  version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b4e301b2efbd1820b3fcd612e86429ed64e1ddf159cd41ffdcd67947c1235180"
+  name = "github.com/qor/session"
+  packages = [
+    ".",
+    "gorilla",
+    "manager",
+  ]
+  pruneopts = "UT"
+  revision = "8206b0adab706a6ef3ee6fabba2584d34429a26a"
+
+[[projects]]
+  digest = "1:c678ac04f0114299ce7d03817c57470fec0ee23f1f547fcb95a6979e72c7a88f"
+  name = "github.com/qor/transition"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4015a3eee19c49a63b1d22beab1c0c084e72c53b"
+  version = "v1.1"
+
+[[projects]]
+  digest = "1:85cb5adb402858878704bc087b8f74fb12d1e56bddbba38e3d94693a14ad93f4"
+  name = "github.com/qor/validations"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f364bca61b46bd48a5e32552a37758864fdf005d"
+  version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e6a29574542c00bb18adb1bfbe629ff88c468c2af2e2e953d3e58eda07165086"
+  name = "github.com/rainycape/unidecode"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "cb7f23ec59bec0d61b19c56cd88cee3d0cc1870c"
 
 [[projects]]
   digest = "1:8bc629776d035c003c7814d4369521afe67fdb8efc4b5f66540d29343b98cf23"
@@ -467,6 +659,14 @@
   version = "v1.2.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:4b0666e7398b9b64deee136f063d9caf0a58a7de52a1ab6540664615b38054ec"
+  name = "github.com/theplant/cldr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9f76f7ce4ee8058b01f92739cf0d0cceaeda3cb2"
+
+[[projects]]
   digest = "1:c268acaa4a4d94a467980e5e91452eb61c460145765293dc0aed48e5e9919cc6"
   name = "github.com/ugorji/go"
   packages = ["codec"]
@@ -483,11 +683,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:aa91545b200c0c8e6cf39bb8eedc86d85d3ed0a208662ed964bef0433839fd3c"
+  digest = "1:bb2e0c5269c54b816dfc046d5c8668bd38a54e8020f688dbabed7e747b00651a"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
+    "html",
+    "html/atom",
     "idna",
     "internal/socks",
     "proxy",
@@ -551,6 +753,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/ahmetb/go-linq",
     "github.com/aryann/difflib",
     "github.com/briandowns/spinner",
     "github.com/docker/docker/api/types",
@@ -575,6 +778,7 @@
     "github.com/oliveagle/jsonpath",
     "github.com/parnurzeal/gorequest",
     "github.com/pkg/errors",
+    "github.com/qor/transition",
     "github.com/sirupsen/logrus",
     "github.com/sirupsen/logrus/hooks/test",
     "github.com/skratchdot/open-golang/open",

--- a/cli/Gopkg.toml
+++ b/cli/Gopkg.toml
@@ -95,3 +95,11 @@
 [[constraint]]
   branch = "master"
   name = "github.com/kardianos/osext"
+
+[[constraint]]
+  name = "github.com/ahmetb/go-linq"
+  version = "3.1.0"
+
+[[constraint]]
+  name = "github.com/qor/transition"
+  version = "1.1.0"

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -396,3 +396,23 @@ func (ec *ExecutionContext) GetMetadataFilePath(format string) (string, error) {
 	}
 	return "", errors.New("unsupported file type")
 }
+
+// GetExistingMetadataFile returns the path to the default metadata file that
+// also exists, json or yaml
+func (ec *ExecutionContext) GetExistingMetadataFile() (string, error) {
+	filename := ""
+	for _, format := range []string{"yaml", "json"} {
+		f, err := ec.GetMetadataFilePath(format)
+		if err != nil {
+			return "", errors.Wrap(err, "cannot get metadata file")
+		}
+
+		filename = f
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			continue
+		}
+		break
+	}
+
+	return filename, nil
+}

--- a/cli/commands/console.go
+++ b/cli/commands/console.go
@@ -193,6 +193,11 @@ func (r *cRouter) setRoutes(migrationDir, metadataFile string, logger *logrus.Lo
 			{
 				settingsAPIs.Any("", api.SettingsAPI)
 			}
+			squashAPIs := migrateAPIs.Group("/squash")
+			{
+				squashAPIs.POST("/create", api.SquashCreateAPI)
+				squashAPIs.POST("/delete", api.SquashDeleteAPI)
+			}
 			migrateAPIs.Any("", api.MigrateAPI)
 		}
 		// Migrate api endpoints and middleware

--- a/cli/commands/metadata.go
+++ b/cli/commands/metadata.go
@@ -19,6 +19,7 @@ func NewMetadataCmd(ec *cli.ExecutionContext) *cobra.Command {
 		SilenceUsage: true,
 	}
 	metadataCmd.AddCommand(
+		newMetadataDiffCmd(ec),
 		newMetadataExportCmd(ec),
 		newMetadataClearCmd(ec),
 		newMetadataReloadCmd(ec),

--- a/cli/commands/metadata_diff.go
+++ b/cli/commands/metadata_diff.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/aryann/difflib"
+	"github.com/ghodss/yaml"
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/mgutz/ansi"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type metadataDiffOptions struct {
+	EC     *cli.ExecutionContext
+	output io.Writer
+
+	// two metadata to diff, 2nd is server if it's empty
+	metadata [2]string
+}
+
+func newMetadataDiffCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &metadataDiffOptions{
+		EC:     ec,
+		output: os.Stdout,
+	}
+
+	metadataDiffCmd := &cobra.Command{
+		Use:   "diff [file1] [file2]",
+		Short: "(PREVIEW) Show a highlighted diff of Hasura metadata",
+		Long: `(PREVIEW) Show changes between two different sets of Hasura metadata.
+By default, shows changes between exported metadata file and server metadata.`,
+		Example: `  # NOTE: This command is in preview, usage and diff format may change.
+
+  # Show changes between server metadata and the exported metadata file:
+  hasura metadata diff
+
+  # Show changes between server metadata and that in local_metadata.yaml:
+  hasura metadata diff local_metadata.yaml
+
+  # Show changes between metadata from metadata.yaml and metadata_old.yaml:
+  hasura metadata diff metadata.yaml metadata_old.yaml`,
+		Args: cobra.MaximumNArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			messageFormat := "Showing diff between %s and %s..."
+			message := ""
+
+			switch len(args) {
+			case 0:
+				// no args, diff exported metadata and metadata on server
+				filename, err := ec.GetExistingMetadataFile()
+				if err != nil {
+					return errors.Wrap(err, "failed getting metadata file")
+				}
+				opts.metadata[0] = filename
+				message = fmt.Sprintf(messageFormat, filename, "the server")
+			case 1:
+				// 1 arg, diff given filename and the metadata on server
+				opts.metadata[0] = args[0]
+				message = fmt.Sprintf(messageFormat, args[0], "the server")
+			case 2:
+				// 2 args, diff given filenames
+				opts.metadata[0] = args[0]
+				opts.metadata[1] = args[1]
+				message = fmt.Sprintf(messageFormat, args[0], args[1])
+			}
+
+			opts.EC.Logger.Info(message)
+			err := opts.run()
+			if err != nil {
+				return errors.Wrap(err, "failed to show metadata diff")
+			}
+			return nil
+		},
+	}
+
+	f := metadataDiffCmd.Flags()
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return metadataDiffCmd
+}
+
+func (o *metadataDiffOptions) run() error {
+	var oldYaml, newYaml []byte
+	var err error
+	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version, true)
+	if err != nil {
+		return err
+	}
+
+	if o.metadata[1] == "" {
+		// get metadata from server
+		m, err := migrateDrv.ExportMetadata()
+		if err != nil {
+			return errors.Wrap(err, "cannot fetch metadata from server")
+		}
+
+		newYaml, err = yaml.Marshal(m)
+		if err != nil {
+			return errors.Wrap(err, "cannot convert metadata from server to yaml")
+		}
+	} else {
+		newYaml, err = ioutil.ReadFile(o.metadata[1])
+		if err != nil {
+			return errors.Wrap(err, "cannot read file")
+		}
+	}
+
+	oldYaml, err = ioutil.ReadFile(o.metadata[0])
+	if err != nil {
+		return errors.Wrap(err, "cannot read file")
+	}
+
+	printDiff(string(oldYaml), string(newYaml), o.output)
+	return nil
+}
+
+func printDiff(before, after string, to io.Writer) {
+	diffs := difflib.Diff(strings.Split(before, "\n"), strings.Split(after, "\n"))
+
+	for _, diff := range diffs {
+		text := diff.Payload
+
+		switch diff.Delta {
+		case difflib.RightOnly:
+			fmt.Fprintf(to, "%s\n", ansi.Color(text, "green"))
+		case difflib.LeftOnly:
+			fmt.Fprintf(to, "%s\n", ansi.Color(text, "red"))
+		case difflib.Common:
+			fmt.Fprintf(to, "%s\n", text)
+		}
+	}
+}

--- a/cli/commands/metadata_diff_test.go
+++ b/cli/commands/metadata_diff_test.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/version"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+var testMetadata1 = `allowlist: []
+functions: []
+query_collections: []
+remote_schemas: []
+tables:
+- array_relationships: []
+  delete_permissions: []
+  event_triggers: []
+  insert_permissions: []
+  is_enum: false
+  object_relationships: []
+  select_permissions: []
+  table: test
+  update_permissions: []
+`
+
+var testMetadata2 = `allowlist: []
+functions: []
+query_collections: []
+remote_schemas: []
+tables:
+- array_relationships: []
+  configuration:
+    custom_column_names: {}
+    custom_root_fields:
+      delete: null
+      insert: null
+      select: null
+      select_aggregate: null
+      select_by_pk: null
+      update: null
+  delete_permissions: []
+  event_triggers: []
+  insert_permissions: []
+  is_enum: false
+  object_relationships: []
+  select_permissions: []
+  table: test
+  update_permissions: []
+`
+
+func TestMetadataDiffCmd(t *testing.T) {
+	endpointURL, err := url.Parse(os.Getenv("HASURA_GRAPHQL_TEST_ENDPOINT"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create migration Dir
+	migrationsDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(migrationsDir)
+
+	metadataFile := filepath.Join(migrationsDir, "metadata.yaml")
+	testMetadataFile1 := filepath.Join(migrationsDir, "testmetadata1.yaml")
+	testMetadataFile2 := filepath.Join(migrationsDir, "testmetadata2.yaml")
+
+	mustWriteFile(t, "", metadataFile, testMetadata1)
+	mustWriteFile(t, "", testMetadataFile1, testMetadata1)
+	mustWriteFile(t, "", testMetadataFile2, testMetadata2)
+
+	logger, _ := test.NewNullLogger()
+	outputFile := new(bytes.Buffer)
+	opts := &metadataDiffOptions{
+		EC: &cli.ExecutionContext{
+			Logger:       logger,
+			Spinner:      spinner.New(spinner.CharSets[7], 100*time.Millisecond),
+			MetadataFile: []string{metadataFile},
+			ServerConfig: &cli.ServerConfig{
+				Endpoint:       endpointURL.String(),
+				AdminSecret:    os.Getenv("HASURA_GRAPHQL_TEST_ADMIN_SECRET"),
+				ParsedEndpoint: endpointURL,
+			},
+		},
+		output: outputFile,
+	}
+
+	opts.EC.Version = version.New()
+	v, err := version.FetchServerVersion(opts.EC.ServerConfig.Endpoint)
+	if err != nil {
+		t.Fatalf("getting server version failed: %v", err)
+	}
+	opts.EC.Version.SetServerVersion(v)
+
+	// Run without args
+	opts.metadata[0] = metadataFile
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+
+	// Run with one arg
+	opts.metadata = [2]string{testMetadataFile1, ""}
+
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+
+	// Run with two args
+	opts.metadata = [2]string{testMetadataFile1, testMetadataFile2}
+
+	err = opts.run()
+	if err != nil {
+		t.Fatalf("failed diffing metadata: %v", err)
+	}
+}

--- a/cli/commands/migrate.go
+++ b/cli/commands/migrate.go
@@ -30,6 +30,7 @@ func NewMigrateCmd(ec *cli.ExecutionContext) *cobra.Command {
 		newMigrateApplyCmd(ec),
 		newMigrateStatusCmd(ec),
 		newMigrateCreateCmd(ec),
+		newMigrateSquashCmd(ec),
 	)
 	return migrateCmd
 }

--- a/cli/commands/migrate_squash.go
+++ b/cli/commands/migrate_squash.go
@@ -1,0 +1,143 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/hasura/graphql-engine/cli"
+	"github.com/hasura/graphql-engine/cli/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+)
+
+func newMigrateSquashCmd(ec *cli.ExecutionContext) *cobra.Command {
+	v := viper.New()
+	opts := &migrateSquashOptions{
+		EC: ec,
+	}
+	migrateSquashCmd := &cobra.Command{
+		Use:   "squash",
+		Short: "(PREVIEW) Squash multiple migrations into a single one",
+		Long:  "(PREVIEW) Squash multiple migrations leading upto the latest one into a single migration file",
+		Example: `  # NOTE: This command is in PREVIEW, correctness is not guaranteed and the usage may change.
+
+  # squash all migrations from version 123 to the latest one:
+  hasura migrate squash --from 123`,
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			ec.Viper = v
+			return ec.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.newVersion = getTime()
+			return opts.run()
+		},
+	}
+
+	f := migrateSquashCmd.Flags()
+	f.Uint64Var(&opts.from, "from", 0, "start squashing form this version")
+	f.StringVar(&opts.name, "name", "squashed", "name for the new squashed migration")
+	f.BoolVar(&opts.deleteSource, "delete-source", false, "delete the source files after squashing without any confirmation")
+
+	f.String("endpoint", "", "http(s) endpoint for Hasura GraphQL Engine")
+	f.String("admin-secret", "", "admin secret for Hasura GraphQL Engine")
+	f.String("access-key", "", "access key for Hasura GraphQL Engine")
+	f.MarkDeprecated("access-key", "use --admin-secret instead")
+
+	// need to create a new viper because https://github.com/spf13/viper/issues/233
+	v.BindPFlag("endpoint", f.Lookup("endpoint"))
+	v.BindPFlag("admin_secret", f.Lookup("admin-secret"))
+	v.BindPFlag("access_key", f.Lookup("access-key"))
+
+	return migrateSquashCmd
+}
+
+type migrateSquashOptions struct {
+	EC *cli.ExecutionContext
+
+	from       uint64
+	name       string
+	newVersion int64
+
+	deleteSource bool
+}
+
+func (o *migrateSquashOptions) run() error {
+	o.EC.Logger.Warnln("This command is currently experimental and hence in preview, correctness of squashed migration is not guaranteed!")
+	o.EC.Spin(fmt.Sprintf("Squashing migrations from %d to latest...", o.from))
+	defer o.EC.Spinner.Stop()
+	migrateDrv, err := newMigrate(o.EC.MigrationDir, o.EC.ServerConfig.ParsedEndpoint, o.EC.ServerConfig.AdminSecret, o.EC.Logger, o.EC.Version, true)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize migrations driver")
+	}
+
+	versions, err := mig.SquashCmd(migrateDrv, o.from, o.newVersion, o.name, o.EC.MigrationDir)
+	o.EC.Spinner.Stop()
+	if err != nil {
+		return errors.Wrap(err, "unable to squash migrations")
+	}
+
+	// squashed migration is generated
+	// TODO: capture keyboard interrupt and offer to delete the squashed migration
+
+	o.EC.Logger.Infof("Created '%d_%s' after squashing '%d' till '%d'", o.newVersion, o.name, versions[0], versions[len(versions)-1])
+
+	if !o.deleteSource {
+		ok := ask2confirmDeleteMigrations(versions, o.EC.Logger)
+		if !ok {
+			return nil
+		}
+	}
+
+	for _, v := range versions {
+		delOptions := mig.CreateOptions{
+			Version:   strconv.FormatInt(v, 10),
+			Directory: o.EC.MigrationDir,
+		}
+		err = delOptions.Delete()
+		if err != nil {
+			return errors.Wrap(err, "unable to delete source file")
+		}
+	}
+	return nil
+}
+
+func ask2confirmDeleteMigrations(versions []int64, log *logrus.Logger) bool {
+	var s string
+
+	log.Infof("The following migrations are squashed into a new one:")
+
+	out := new(tabwriter.Writer)
+	buf := &bytes.Buffer{}
+	out.Init(buf, 0, 8, 2, ' ', 0)
+	w := util.NewPrefixWriter(out)
+	for _, version := range versions {
+		w.Write(util.LEVEL_0, "%d\n",
+			version,
+		)
+	}
+	_ = out.Flush()
+	fmt.Println(buf.String())
+	log.Infof("Do you want to delete these migration source files? (y/N)")
+
+	_, err := fmt.Scan(&s)
+	if err != nil {
+		log.Error("unable to take user input, skipping deleting files")
+		return false
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	if s == "y" || s == "yes" {
+		return true
+	}
+	return false
+}

--- a/cli/migrate/api/migrate.go
+++ b/cli/migrate/api/migrate.go
@@ -55,6 +55,19 @@ func MigrateAPI(c *gin.Context) {
 
 	// Switch on request method
 	switch c.Request.Method {
+	case "GET":
+		// Rescan file system
+		err := t.ReScan()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+			return
+		}
+		status, err := t.GetStatus()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: "Something went wrong"})
+			return
+		}
+		c.JSON(http.StatusOK, status)
 	case "POST":
 		var request Request
 
@@ -65,7 +78,6 @@ func MigrateAPI(c *gin.Context) {
 		}
 
 		startTime := time.Now()
-		// Convert to Millisecond
 		timestamp := startTime.UnixNano() / int64(time.Millisecond)
 
 		createOptions := cmd.New(timestamp, request.Name, sourceURL.Path)

--- a/cli/migrate/api/settings.go
+++ b/cli/migrate/api/settings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hasura/graphql-engine/cli/migrate"
 )
 
-type SettingReqeust struct {
+type SettingRequest struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
@@ -37,7 +37,7 @@ func SettingsAPI(c *gin.Context) {
 		}
 		c.JSON(200, &gin.H{name: setting})
 	case "PUT":
-		var request SettingReqeust
+		var request SettingRequest
 		// Bind Request body to Request struct
 		if c.BindJSON(&request) != nil {
 			c.JSON(500, &Response{Code: "internal_error", Message: "Something went wrong"})

--- a/cli/migrate/api/squash.go
+++ b/cli/migrate/api/squash.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hasura/graphql-engine/cli/migrate"
+	"github.com/hasura/graphql-engine/cli/migrate/cmd"
+	mig "github.com/hasura/graphql-engine/cli/migrate/cmd"
+)
+
+type squashCreateRequest struct {
+	Name    string `json:"name"`
+	From    uint64 `json:"from"`
+	version int64
+}
+
+type squashDeleteRequest struct {
+	Versions []int64 `json:"migrations"`
+}
+
+func (s *squashCreateRequest) setDefaults() {
+	if s.Name == "" {
+		s.Name = "default_squash"
+	}
+	startTime := time.Now()
+	s.version = startTime.UnixNano() / int64(time.Millisecond)
+}
+
+func SquashCreateAPI(c *gin.Context) {
+	migratePtr, ok := c.Get("migrate")
+	if !ok {
+		return
+	}
+
+	sourcePtr, ok := c.Get("filedir")
+	if !ok {
+		return
+	}
+
+	t := migratePtr.(*migrate.Migrate)
+	sourceURL := sourcePtr.(*url.URL)
+
+	var request squashCreateRequest
+	// Bind Request body to Request struct
+	if c.BindJSON(&request) != nil {
+		c.JSON(500, &Response{Code: "internal_error", Message: "Something went wrong"})
+		return
+	}
+	request.setDefaults()
+	// Rescan file system
+	err := t.ReScan()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+		return
+	}
+	versions, err := cmd.SquashCmd(t, request.From, request.version, request.Name, sourceURL.Path)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), DataAPIError) {
+			c.JSON(http.StatusBadRequest, &Response{Code: "data_api_error", Message: strings.TrimPrefix(err.Error(), DataAPIError)})
+			return
+		}
+
+		if err == migrate.ErrNoMigrationMode {
+			c.JSON(http.StatusBadRequest, &Response{Code: "migration_mode_disabled", Message: err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, &Response{Code: "internal_error", Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"version": request.version, "squashed_migrations": versions})
+}
+
+func SquashDeleteAPI(c *gin.Context) {
+	sourcePtr, ok := c.Get("filedir")
+	if !ok {
+		return
+	}
+
+	sourceURL := sourcePtr.(*url.URL)
+
+	var request squashDeleteRequest
+	// Bind Request body to Request struct
+	if c.BindJSON(&request) != nil {
+		c.JSON(500, &Response{Code: "internal_error", Message: "Something went wrong"})
+		return
+	}
+
+	for _, v := range request.Versions {
+		delOptions := mig.CreateOptions{
+			Version:   strconv.FormatInt(v, 10),
+			Directory: sourceURL.Path,
+		}
+		err := delOptions.Delete()
+		if err != nil {
+			c.JSON(500, &Response{Code: "internal_error", Message: "Something went wrong"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Migrations deleted"})
+}

--- a/cli/migrate/database/driver.go
+++ b/cli/migrate/database/driver.go
@@ -104,6 +104,10 @@ type Driver interface {
 
 	Read(version uint64) (ok bool)
 
+	PushToList(migration io.Reader, fileType string, list *CustomList) error
+
+	Squash(list *CustomList, ret chan<- interface{})
+
 	SettingsDriver
 
 	MetadataDriver

--- a/cli/migrate/database/hasuradb/squash.go
+++ b/cli/migrate/database/hasuradb/squash.go
@@ -1,0 +1,1258 @@
+package hasuradb
+
+import (
+	"container/list"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/hasura/graphql-engine/cli/migrate/database"
+	"github.com/pkg/errors"
+
+	"github.com/ahmetb/go-linq"
+
+	yaml "github.com/ghodss/yaml"
+	"github.com/qor/transition"
+)
+
+type CustomQuery linq.Query
+
+func (q CustomQuery) MergeEventTriggers(squashList *database.CustomList) error {
+	eventTriggerTransition := transition.New(&eventTriggerConfig{})
+	eventTriggerTransition.Initial("new")
+	eventTriggerTransition.State("created")
+	eventTriggerTransition.State("deleted")
+
+	eventTriggerTransition.Event("create_event_trigger").To("created").From("new", "deleted")
+	eventTriggerTransition.Event("delete_event_trigger").To("deleted").From("new", "created")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == "" {
+			continue
+		}
+		evKey := g.Key.(string)
+		evCfg := eventTriggerConfig{
+			name: evKey,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *trackTableInput:
+				err := eventTriggerTransition.Trigger("create_event_trigger", &evCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *unTrackTableInput:
+				err := eventTriggerTransition.Trigger("delete_event_trigger", &evCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeRelationships(squashList *database.CustomList) error {
+	relationshipTransition := transition.New(&relationshipConfig{})
+	relationshipTransition.Initial("new")
+	relationshipTransition.State("created")
+	relationshipTransition.State("dropped")
+
+	relationshipTransition.Event("create_relationship").To("created").From("new", "dropped")
+	relationshipTransition.Event("drop_relationship").To("dropped").From("new", "created")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		relKey := g.Key.(relationshipMap)
+		relCfg := relationshipConfig{
+			tableName:  relKey.tableName,
+			schemaName: relKey.schemaName,
+			name:       relKey.name,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch obj := element.Value.(type) {
+			case *createObjectRelationshipInput:
+				err := relationshipTransition.Trigger("create_relationship", &relCfg, nil)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("relationship %s %s", obj.Name, relKey.name))
+				}
+				prevElems = append(prevElems, element)
+			case *createArrayRelationshipInput:
+				err := relationshipTransition.Trigger("create_relationship", &relCfg, nil)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("relationship %s %s", obj.Name, relKey.name))
+				}
+				prevElems = append(prevElems, element)
+			case *setRelationshipCommentInput:
+				if len(prevElems) != 0 {
+					if rel, ok := prevElems[0].Value.(*createObjectRelationshipInput); ok {
+						rel.Comment = obj.Comment
+						continue
+					}
+
+					if rel, ok := prevElems[0].Value.(*createArrayRelationshipInput); ok {
+						rel.Comment = obj.Comment
+						continue
+					}
+				}
+				prevElems = append(prevElems, element)
+			case *dropRelationshipInput:
+				if relCfg.GetState() == "created" {
+					prevElems = append(prevElems, element)
+				}
+				err := relationshipTransition.Trigger("drop_relationship", &relCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergePermissions(squashList *database.CustomList) error {
+	permissionTransition := transition.New(&permissionConfig{})
+	permissionTransition.Initial("new")
+	permissionTransition.State("created")
+	permissionTransition.State("dropped")
+
+	permissionTransition.Event("create_permission").To("created").From("new", "dropped")
+	permissionTransition.Event("drop_permission").To("dropped").From("new", "created")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		permKey := g.Key.(permissionMap)
+		permCfg := permissionConfig{
+			tableName:  permKey.tableName,
+			schemaName: permKey.schemaName,
+			permType:   permKey.permType,
+			role:       permKey.Role,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch obj := element.Value.(type) {
+			case *createInsertPermissionInput, *createSelectPermissionInput, *createUpdatePermissionInput, *createDeletePermissionInput:
+				err := permissionTransition.Trigger("create_permission", &permCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *setPermissionCommentInput:
+				if len(prevElems) != 0 {
+					if perm, ok := prevElems[0].Value.(*createInsertPermissionInput); ok {
+						perm.Comment = obj.Comment
+						continue
+					}
+
+					if perm, ok := prevElems[0].Value.(*createSelectPermissionInput); ok {
+						perm.Comment = obj.Comment
+						continue
+					}
+
+					if perm, ok := prevElems[0].Value.(*createUpdatePermissionInput); ok {
+						perm.Comment = obj.Comment
+						continue
+					}
+
+					if perm, ok := prevElems[0].Value.(*createDeletePermissionInput); ok {
+						perm.Comment = obj.Comment
+						continue
+					}
+				}
+				prevElems = append(prevElems, element)
+			case *dropInsertPermissionInput, *dropSelectPermissionInput, *dropUpdatePermissionInput, *dropDeletePermissionInput:
+				if permCfg.GetState() == "created" {
+					prevElems = append(prevElems, element)
+				}
+				err := permissionTransition.Trigger("drop_permission", &permCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeComputedFields(squashList *database.CustomList) error {
+	computedFieldTransition := transition.New(&computedFieldConfig{})
+	computedFieldTransition.Initial("new")
+	computedFieldTransition.State("added")
+	computedFieldTransition.State("dropped")
+
+	computedFieldTransition.Event("add_computed_field").To("added").From("new", "dropped")
+	computedFieldTransition.Event("drop_computed_field").To("dropped").From("new", "added")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		cfKey := g.Key.(computedFieldMap)
+		cfCfg := computedFieldConfig{
+			tableName:  cfKey.tableName,
+			schemaName: cfKey.schemaName,
+			name:       cfKey.name,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch obj := element.Value.(type) {
+			case *addComputedFieldInput:
+				err := computedFieldTransition.Trigger("add_computed_field", &cfCfg, nil)
+				if err != nil {
+					return errors.Wrap(err, fmt.Sprintf("computed field %s", obj.Name))
+				}
+				prevElems = append(prevElems, element)
+			case *dropComputedFieldInput:
+				if cfCfg.GetState() == "added" {
+					prevElems = append(prevElems, element)
+				}
+				err := computedFieldTransition.Trigger("drop_computed_field", &cfCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeTableCustomFields(squashList *database.CustomList) error {
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		var prevElem *list.Element
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *setTableCustomFieldsV2Input:
+				if prevElem != nil {
+					squashList.Remove(prevElem)
+				}
+				prevElem = element
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeTables(squashList *database.CustomList) error {
+	tableTransition := transition.New(&tableConfig{})
+	tableTransition.Initial("new")
+	tableTransition.State("tracked")
+	tableTransition.State("untracked")
+
+	tableTransition.Event("track_table").To("tracked").From("new", "untracked")
+	tableTransition.Event("untrack_table").To("untracked").From("new", "tracked")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		tblKey := g.Key.(tableMap)
+		tblCfg := tableConfig{
+			name:   tblKey.name,
+			schema: tblKey.schema,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch args := element.Value.(type) {
+			case *trackTableInput, *trackTableV2Input:
+				err := tableTransition.Trigger("track_table", &tblCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *unTrackTableInput:
+				if tblCfg.GetState() == "tracked" {
+					prevElems = append(prevElems, element)
+				}
+				err := tableTransition.Trigger("untrack_table", &tblCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			case *createEventTriggerInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create event trigger %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *deleteEventTriggerInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot delete event trigger %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createObjectRelationshipInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create object relationship %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createArrayRelationshipInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create array relationship %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *setRelationshipCommentInput:
+				prevElems = append(prevElems, element)
+			case *dropRelationshipInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop relationship %s when table %s on schema %s is untracked", args.RelationShip, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createInsertPermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create insert permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createSelectPermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create select permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createUpdatePermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create update permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *createDeletePermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot create delete permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *setPermissionCommentInput:
+				prevElems = append(prevElems, element)
+			case *dropInsertPermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop insert permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *dropSelectPermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop select permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *dropUpdatePermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop update permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *dropDeletePermissionInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop delete permission for %s role when table %s on schema %s is untracked", args.Role, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *addComputedFieldInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot add computed field %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *dropComputedFieldInput:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot drop computed field %s when table %s on schema %s is untracked", args.Name, tblCfg.name, tblCfg.schema)
+				}
+				prevElems = append(prevElems, element)
+			case *setTableCustomFieldsV2Input:
+				if tblCfg.GetState() == "untracked" {
+					return fmt.Errorf("cannot set custom fields when table %s on schema %s is untracked", tblCfg.name, tblCfg.schema)
+				}
+				if len(prevElems) != 0 {
+					if track, ok := prevElems[0].Value.(*trackTableV2Input); ok {
+						track.Configuration = args.tableConfiguration
+						squashList.Remove(element)
+						continue
+					}
+				}
+				prevElems = append(prevElems, element)
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeFunctions(squashList *database.CustomList) error {
+	functionTransition := transition.New(&functionConfig{})
+	functionTransition.Initial("new")
+	functionTransition.State("tracked")
+	functionTransition.State("untracked")
+
+	functionTransition.Event("track_function").To("tracked").From("new", "untracked")
+	functionTransition.Event("untrack_function").To("untracked").From("new", "tracked")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		funcKey := g.Key.(tableMap)
+		funcCfg := functionConfig{
+			name:   funcKey.name,
+			schema: funcKey.schema,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *trackFunctionInput:
+				err := functionTransition.Trigger("track_function", &funcCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *unTrackFunctionInput:
+				if funcCfg.GetState() == "tracked" {
+					prevElems = append(prevElems, element)
+				}
+				err := functionTransition.Trigger("untrack_function", &funcCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeRemoteSchemas(squashList *database.CustomList) error {
+	remoteSchemaTransition := transition.New(&remoteSchemaConfig{})
+	remoteSchemaTransition.Initial("new")
+	remoteSchemaTransition.State("added")
+	remoteSchemaTransition.State("removed")
+
+	remoteSchemaTransition.Event("add_remote_schema").To("added").From("new", "removed")
+	remoteSchemaTransition.Event("remove_remote_schema").To("removed").From("new", "added")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		remoteSchemaKey := g.Key.(string)
+		rsCfg := remoteSchemaConfig{
+			name: remoteSchemaKey,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *addRemoteSchemaInput:
+				err := remoteSchemaTransition.Trigger("add_remote_schema", &rsCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *removeRemoteSchemaInput:
+				if rsCfg.GetState() == "added" {
+					prevElems = append(prevElems, element)
+				}
+				err := remoteSchemaTransition.Trigger("remove_remote_schema", &rsCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeQueryInCollections(squashList *database.CustomList) error {
+	queryInCollectionTransition := transition.New(&queryInCollectionConfig{})
+	queryInCollectionTransition.Initial("new")
+	queryInCollectionTransition.State("added")
+	queryInCollectionTransition.State("dropped")
+
+	queryInCollectionTransition.Event("add_query_to_collection").To("added").From("new", "dropped")
+	queryInCollectionTransition.Event("drop_query_from_collection").To("dropped").From("new", "added")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		queryInCollectionKey := g.Key.(*queryInCollectionMap)
+		qicCfg := queryInCollectionConfig{
+			collectionName: queryInCollectionKey.collectionName,
+			queryName:      queryInCollectionKey.queryName,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *addQueryToCollectionInput:
+				err := queryInCollectionTransition.Trigger("add_query_to_collection", &qicCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *dropQueryFromCollectionInput:
+				if qicCfg.GetState() == "added" {
+					prevElems = append(prevElems, element)
+				}
+				err := queryInCollectionTransition.Trigger("drop_query_from_collection", &qicCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeAllowLists(squashList *database.CustomList) error {
+	allowListTransition := transition.New(&allowListConfig{})
+	allowListTransition.Initial("new")
+	allowListTransition.State("added")
+	allowListTransition.State("removed")
+
+	allowListTransition.Event("add_collection_to_allowlist").To("added").From("new", "removed")
+	allowListTransition.Event("drop_collection_from_allowlist").To("removed").From("new", "added")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		allowListKey := g.Key.(string)
+		alCfg := allowListConfig{
+			collection: allowListKey,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch element.Value.(type) {
+			case *addRemoteSchemaInput:
+				err := allowListTransition.Trigger("add_collection_to_allowlist", &alCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *removeRemoteSchemaInput:
+				if alCfg.GetState() == "added" {
+					prevElems = append(prevElems, element)
+				}
+				err := allowListTransition.Trigger("drop_collection_from_allowlist", &alCfg, nil)
+				if err != nil {
+					return err
+				}
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (q CustomQuery) MergeQueryCollections(squashList *database.CustomList) error {
+	queryCollectionTransition := transition.New(&queryCollectionConfig{})
+	queryCollectionTransition.Initial("new")
+	queryCollectionTransition.State("created")
+	queryCollectionTransition.State("dropped")
+
+	queryCollectionTransition.Event("create_query_collection").To("created").From("new", "dropped")
+	queryCollectionTransition.Event("drop_query_collection").To("dropped").From("new", "created")
+
+	next := q.Iterate()
+
+	for item, ok := next(); ok; item, ok = next() {
+		g := item.(linq.Group)
+		if g.Key == nil {
+			continue
+		}
+		queryCollectionKey := g.Key.(string)
+		qcCfg := queryCollectionConfig{
+			name: queryCollectionKey,
+		}
+		prevElems := make([]*list.Element, 0)
+		for _, val := range g.Group {
+			element := val.(*list.Element)
+			switch args := element.Value.(type) {
+			case *createQueryCollectionInput:
+				err := queryCollectionTransition.Trigger("create_query_collection", &qcCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+			case *addQueryToCollectionInput:
+				if qcCfg.GetState() == "dropped" {
+					return fmt.Errorf("cannot add query %s to a collection %s when it is dropped", args.QueryName, qcCfg.name)
+				}
+
+				if len(prevElems) != 0 {
+					if query, ok := prevElems[0].Value.(*createQueryCollectionInput); ok {
+						query.Definition.Queries = append(query.Definition.Queries, collectionQuery{
+							Name:  args.QueryName,
+							Query: args.Query,
+						})
+						squashList.Remove(element)
+						continue
+					}
+				}
+				prevElems = append(prevElems, element)
+			case *dropQueryFromCollectionInput:
+				prevElems = append(prevElems, element)
+			case *addCollectionToAllowListInput:
+				if qcCfg.GetState() == "dropped" {
+					return fmt.Errorf("cannot add collection %s to allowlist when it is dropped", qcCfg.name)
+				}
+				qcCfg.allowList = true
+				prevElems = append(prevElems, element)
+			case *dropCollectionFromAllowListInput:
+				qcCfg.allowList = false
+				prevElems = append(prevElems, element)
+			case *dropQueryCollectionInput:
+				if !args.Cascade && qcCfg.allowList {
+					// return error stating that without cascade set allow list wont be dropped
+					return fmt.Errorf("cannot drop collection %s from allowlist when cascade is not set to true", qcCfg.name)
+				}
+				if qcCfg.GetState() == "created" {
+					prevElems = append(prevElems, element)
+				}
+				err := queryCollectionTransition.Trigger("drop_query_collection", &qcCfg, nil)
+				if err != nil {
+					return err
+				}
+				prevElems = append(prevElems, element)
+				// drop previous elements
+				for _, e := range prevElems {
+					squashList.Remove(e)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type customList struct {
+	*list.List
+}
+
+func (c *customList) Iterate() linq.Iterator {
+	length := c.Len()
+	var prevElem *list.Element
+	i := 0
+	return func() (item interface{}, ok bool) {
+		if length == 0 {
+			return
+		}
+
+		if i == 0 {
+			prevElem = c.Front()
+			i++
+		} else {
+			prevElem = prevElem.Next()
+			if prevElem == nil {
+				return
+			}
+		}
+		return prevElem, true
+	}
+}
+
+func (h *HasuraDB) PushToList(migration io.Reader, fileType string, l *database.CustomList) error {
+	migr, err := ioutil.ReadAll(migration)
+	if err != nil {
+		return err
+	}
+	body := string(migr[:])
+	switch fileType {
+	case "sql":
+		if body == "" {
+			break
+		}
+		tt := &runSQLInput{
+			SQL: body,
+		}
+		l.PushBack(tt)
+	case "meta":
+		var t []newHasuraIntefaceQuery
+		err := yaml.Unmarshal(migr, &t)
+		if err != nil {
+			return err
+		}
+		for _, v := range t {
+			switch actionType := v.Args.(type) {
+			case *replaceMetadataInput:
+				// Remove previous metadata actions
+				var next *list.Element
+				for e := l.Front(); e != nil; e = next {
+					next = e.Next()
+					switch e.Value.(type) {
+					case *runSQLInput:
+						// do nothing
+					default:
+						l.Remove(e)
+					}
+				}
+				// add clear Metadata
+				cm := &clearMetadataInput{}
+				l.PushBack(cm)
+				// convert replace metadata to actions
+				actionType.convertToMetadataActions(l)
+			case *clearMetadataInput:
+				// Remove previous metadata actions
+				var next *list.Element
+				for e := l.Front(); e != nil; e = next {
+					next = e.Next()
+					switch e.Value.(type) {
+					case *runSQLInput:
+						// do nothing
+					default:
+						l.Remove(e)
+					}
+				}
+				l.PushBack(actionType)
+			default:
+				l.PushBack(actionType)
+			}
+		}
+	default:
+		return fmt.Errorf("Invalid migration file type")
+	}
+	return nil
+}
+
+func (h *HasuraDB) Squash(l *database.CustomList, ret chan<- interface{}) {
+	eventTriggersGroup := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) string {
+			switch args := element.Value.(type) {
+			case *createEventTriggerInput:
+				return args.Name
+			case *deleteEventTriggerInput:
+				return args.Name
+			}
+			return ""
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err := eventTriggersGroup.MergeEventTriggers(l)
+	if err != nil {
+		ret <- err
+	}
+
+	relationshipsGroup := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *createObjectRelationshipInput:
+				return relationshipMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Name,
+				}
+			case *createArrayRelationshipInput:
+				return relationshipMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Name,
+				}
+			case *setRelationshipCommentInput:
+				return relationshipMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Name,
+				}
+			case *dropRelationshipInput:
+				return relationshipMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.RelationShip,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = relationshipsGroup.MergeRelationships(l)
+	if err != nil {
+		ret <- err
+	}
+
+	permissionsGroup := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *createInsertPermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"insert",
+					args.Role,
+				}
+			case *createSelectPermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"select",
+					args.Role,
+				}
+			case *createUpdatePermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"update",
+					args.Role,
+				}
+			case *createDeletePermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"delete",
+					args.Role,
+				}
+			case *dropInsertPermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"insert",
+					args.Role,
+				}
+			case *dropSelectPermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"select",
+					args.Role,
+				}
+			case *dropUpdatePermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"update",
+					args.Role,
+				}
+			case *dropDeletePermissionInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					"delete",
+					args.Role,
+				}
+			case *setPermissionCommentInput:
+				return permissionMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Type,
+					args.Role,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = permissionsGroup.MergePermissions(l)
+	if err != nil {
+		ret <- err
+	}
+
+	computedFieldGroup := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *addComputedFieldInput:
+				return computedFieldMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Name,
+				}
+			case *dropComputedFieldInput:
+				return computedFieldMap{
+					args.Table.Name,
+					args.Table.Schema,
+					args.Name,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = computedFieldGroup.MergeComputedFields(l)
+	if err != nil {
+		ret <- err
+	}
+
+	tableCustomFieldGroup := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *setTableCustomFieldsV2Input:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = tableCustomFieldGroup.MergeTableCustomFields(l)
+	if err != nil {
+		ret <- err
+	}
+
+	tableGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *trackTableInput:
+				return tableMap{
+					args.tableSchema.Name,
+					args.tableSchema.Schema,
+				}
+			case *trackTableV2Input:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *unTrackTableInput:
+				return tableMap{
+					args.tableSchema.Name,
+					args.tableSchema.Schema,
+				}
+			case *setTableCustomFieldsV2Input:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createEventTriggerInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createObjectRelationshipInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createArrayRelationshipInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropRelationshipInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createInsertPermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createSelectPermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createUpdatePermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *createDeletePermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropInsertPermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropSelectPermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropUpdatePermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropDeletePermissionInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *addComputedFieldInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			case *dropComputedFieldInput:
+				return tableMap{
+					args.Table.Name,
+					args.Table.Schema,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = tableGroups.MergeTables(l)
+	if err != nil {
+		ret <- err
+	}
+
+	functionGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case *trackFunctionInput:
+				return tableMap{
+					args.Name,
+					args.Schema,
+				}
+			case *unTrackFunctionInput:
+				return tableMap{
+					args.Name,
+					args.Schema,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = functionGroups.MergeFunctions(l)
+	if err != nil {
+		ret <- err
+	}
+
+	remoteSchemaGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) string {
+			switch args := element.Value.(type) {
+			case *addRemoteSchemaInput:
+				return args.Name
+			case *removeRemoteSchemaInput:
+				return args.Name
+			}
+			return ""
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = remoteSchemaGroups.MergeRemoteSchemas(l)
+	if err != nil {
+		ret <- err
+	}
+
+	allowListGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) string {
+			switch args := element.Value.(type) {
+			case *addCollectionToAllowListInput:
+				return args.Collection
+			case *dropCollectionFromAllowListInput:
+				return args.Collection
+			}
+			return ""
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = allowListGroups.MergeAllowLists(l)
+	if err != nil {
+		ret <- err
+	}
+
+	queryInCollectionGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) interface{} {
+			switch args := element.Value.(type) {
+			case addQueryToCollectionInput:
+				return queryInCollectionMap{
+					collectionName: args.CollectionName,
+					queryName:      args.QueryName,
+				}
+			case dropQueryFromCollectionInput:
+				return queryInCollectionMap{
+					collectionName: args.CollectionName,
+					queryName:      args.QueryName,
+				}
+			}
+			return nil
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = queryInCollectionGroups.MergeQueryInCollections(l)
+	if err != nil {
+		ret <- err
+	}
+
+	queryCollectionGroups := CustomQuery(linq.FromIterable(l).GroupByT(
+		func(element *list.Element) string {
+			switch args := element.Value.(type) {
+			case *createQueryCollectionInput:
+				return args.Name
+			case *addQueryToCollectionInput:
+				return args.CollectionName
+			case *dropQueryFromCollectionInput:
+				return args.CollectionName
+			case *addCollectionToAllowListInput:
+				return args.Collection
+			case *dropCollectionFromAllowListInput:
+				return args.Collection
+			case *dropQueryCollectionInput:
+				return args.Collection
+			}
+			return ""
+		}, func(element *list.Element) *list.Element {
+			return element
+		},
+	))
+	err = queryCollectionGroups.MergeQueryCollections(l)
+	if err != nil {
+		ret <- err
+	}
+
+	for e := l.Front(); e != nil; e = e.Next() {
+		q := HasuraInterfaceQuery{
+			Args: e.Value,
+		}
+		switch args := e.Value.(type) {
+		case *trackTableInput:
+			q.Type = trackTable
+		case *trackTableV2Input:
+			q.Version = v2
+			q.Type = trackTable
+		case *unTrackTableInput:
+			q.Type = untrackTable
+		case *setTableCustomFieldsV2Input:
+			q.Version = v2
+			q.Type = setTableCustomFields
+		case *createObjectRelationshipInput:
+			q.Type = createObjectRelationship
+		case *createArrayRelationshipInput:
+			q.Type = createArrayRelationship
+		case *setRelationshipCommentInput:
+			q.Type = setRelationshipComment
+		case *dropRelationshipInput:
+			q.Type = dropRelationship
+		case *createInsertPermissionInput:
+			q.Type = createInsertPermission
+		case *dropInsertPermissionInput:
+			q.Type = dropInsertPermission
+		case *createSelectPermissionInput:
+			q.Type = createSelectPermission
+		case *dropSelectPermissionInput:
+			q.Type = dropSelectPermission
+		case *createUpdatePermissionInput:
+			q.Type = createUpdatePermission
+		case *dropUpdatePermissionInput:
+			q.Type = dropUpdatePermission
+		case *createDeletePermissionInput:
+			q.Type = createDeletePermission
+		case *dropDeletePermissionInput:
+			q.Type = dropDeletePermission
+		case *setPermissionCommentInput:
+			q.Type = setPermissionComment
+		case *trackFunctionInput:
+			q.Type = trackFunction
+		case *unTrackFunctionInput:
+			q.Type = unTrackFunction
+		case *createEventTriggerInput:
+			q.Type = createEventTrigger
+		case *deleteEventTriggerInput:
+			q.Type = deleteEventTrigger
+		case *addRemoteSchemaInput:
+			q.Type = addRemoteSchema
+		case *removeRemoteSchemaInput:
+			q.Type = removeRemoteSchema
+		case *createQueryCollectionInput:
+			q.Type = createQueryCollection
+		case *dropQueryCollectionInput:
+			q.Type = dropQueryCollection
+		case *addQueryToCollectionInput:
+			q.Type = addQueryToCollection
+		case *dropQueryFromCollectionInput:
+			q.Type = dropQueryFromCollection
+		case *addCollectionToAllowListInput:
+			q.Type = addCollectionToAllowList
+		case *dropCollectionFromAllowListInput:
+			q.Type = dropCollectionFromAllowList
+		case *clearMetadataInput:
+			q.Type = clearMetadata
+		case *addComputedFieldInput:
+			q.Type = addComputedField
+		case *dropComputedFieldInput:
+			q.Type = dropComputedField
+		case *runSQLInput:
+			ret <- []byte(args.SQL)
+			continue
+		default:
+			ret <- fmt.Errorf("invalid metadata action")
+			return
+		}
+		ret <- q
+	}
+}

--- a/cli/migrate/database/hasuradb/types.go
+++ b/cli/migrate/database/hasuradb/types.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hasura/graphql-engine/cli/migrate/database"
+
+	"github.com/qor/transition"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -23,8 +26,115 @@ func (h *HasuraInterfaceBulk) ResetArgs() {
 }
 
 type HasuraInterfaceQuery struct {
-	Type string      `json:"type" yaml:"type"`
-	Args interface{} `json:"args" yaml:"args"`
+	Type    requestTypes    `json:"type" yaml:"type"`
+	Version metadataVersion `json:"version,omitempty" yaml:"version,omitempty"`
+	Args    interface{}     `json:"args" yaml:"args"`
+}
+
+type metadataVersion int
+
+const (
+	v1 metadataVersion = 1
+	v2                 = 2
+)
+
+type newHasuraIntefaceQuery struct {
+	Type    requestTypes    `json:"type" yaml:"type"`
+	Version metadataVersion `json:"version,omitempty" yaml:"version,omitempty"`
+	Args    interface{}     `json:"args" yaml:"args"`
+}
+
+func (h *newHasuraIntefaceQuery) UnmarshalJSON(b []byte) error {
+	type t newHasuraIntefaceQuery
+	var q t
+	if err := json.Unmarshal(b, &q); err != nil {
+		return err
+	}
+	if q.Version == 0 {
+		q.Version = v1
+	}
+	argBody, err := json.Marshal(q.Args)
+	if err != nil {
+		return err
+	}
+	switch q.Type {
+	case trackTable, addExistingTableOrView:
+		switch q.Version {
+		case v2:
+			q.Args = &trackTableV2Input{}
+		default:
+			q.Args = &trackTableInput{}
+		}
+	case setTableCustomFields:
+		q.Args = &setTableCustomFieldsV2Input{}
+	case untrackTable:
+		q.Args = &unTrackTableInput{}
+	case createObjectRelationship:
+		q.Args = &createObjectRelationshipInput{}
+	case createArrayRelationship:
+		q.Args = &createArrayRelationshipInput{}
+	case setRelationshipComment:
+		q.Args = &setRelationshipCommentInput{}
+	case dropRelationship:
+		q.Args = &dropRelationshipInput{}
+	case createInsertPermission:
+		q.Args = &createInsertPermissionInput{}
+	case dropInsertPermission:
+		q.Args = &dropInsertPermissionInput{}
+	case createSelectPermission:
+		q.Args = &createSelectPermissionInput{}
+	case dropSelectPermission:
+		q.Args = &dropSelectPermissionInput{}
+	case createUpdatePermission:
+		q.Args = &createUpdatePermissionInput{}
+	case dropUpdatePermission:
+		q.Args = &dropUpdatePermissionInput{}
+	case createDeletePermission:
+		q.Args = &createDeletePermissionInput{}
+	case dropDeletePermission:
+		q.Args = &dropDeletePermissionInput{}
+	case trackFunction:
+		q.Args = &trackFunctionInput{}
+	case unTrackFunction:
+		q.Args = &unTrackFunctionInput{}
+	case createEventTrigger:
+		q.Args = &createEventTriggerInput{}
+	case deleteEventTrigger:
+		q.Args = &deleteEventTriggerInput{}
+	case addRemoteSchema:
+		q.Args = &addRemoteSchemaInput{}
+	case removeRemoteSchema:
+		q.Args = &removeRemoteSchemaInput{}
+	case createQueryCollection:
+		q.Args = &createQueryCollectionInput{}
+	case dropQueryCollection:
+		q.Args = &dropQueryCollectionInput{}
+	case addQueryToCollection:
+		q.Args = &addQueryToCollectionInput{}
+	case dropQueryFromCollection:
+		q.Args = &dropQueryFromCollectionInput{}
+	case addCollectionToAllowList:
+		q.Args = &addCollectionToAllowListInput{}
+	case dropCollectionFromAllowList:
+		q.Args = &dropCollectionFromAllowListInput{}
+	case replaceMetadata:
+		q.Args = &replaceMetadataInput{}
+	case clearMetadata:
+		q.Args = &clearMetadataInput{}
+	case runSQL:
+		q.Args = &runSQLInput{}
+	case addComputedField:
+		q.Args = &addComputedFieldInput{}
+	case dropComputedField:
+		q.Args = &dropComputedFieldInput{}
+	default:
+		return fmt.Errorf("cannot squash type %s", h.Type)
+	}
+	if err := json.Unmarshal(argBody, &q.Args); err != nil {
+		return err
+	}
+	*h = newHasuraIntefaceQuery(q)
+	return nil
 }
 
 type HasuraQuery struct {
@@ -135,4 +245,540 @@ func (h *HasuraError) Error(isCMD bool) error {
 type HasuraSQLRes struct {
 	ResultType string     `json:"result_type"`
 	Result     [][]string `json:"result"`
+}
+
+type requestTypes string
+
+const (
+	trackTable                  requestTypes = "track_table"
+	addExistingTableOrView                   = "add_existing_table_or_view"
+	setTableCustomFields                     = "set_table_custom_fields"
+	untrackTable                             = "untrack_table"
+	trackFunction                            = "track_function"
+	unTrackFunction                          = "untrack_function"
+	createObjectRelationship                 = "create_object_relationship"
+	createArrayRelationship                  = "create_array_relationship"
+	dropRelationship                         = "drop_relationship"
+	setRelationshipComment                   = "set_relationship_comment"
+	createInsertPermission                   = "create_insert_permission"
+	dropInsertPermission                     = "drop_insert_permission"
+	createSelectPermission                   = "create_select_permission"
+	dropSelectPermission                     = "drop_select_permission"
+	createUpdatePermission                   = "create_update_permission"
+	dropUpdatePermission                     = "drop_update_permission"
+	createDeletePermission                   = "create_delete_permission"
+	dropDeletePermission                     = "drop_delete_permission"
+	setPermissionComment                     = "set_permission_comment"
+	createEventTrigger                       = "create_event_trigger"
+	deleteEventTrigger                       = "delete_event_trigger"
+	addRemoteSchema                          = "add_remote_schema"
+	removeRemoteSchema                       = "remove_remote_schema"
+	createQueryCollection                    = "create_query_collection"
+	dropQueryCollection                      = "drop_query_collection"
+	addQueryToCollection                     = "add_query_to_collection"
+	dropQueryFromCollection                  = "drop_query_from_collection"
+	addCollectionToAllowList                 = "add_collection_to_allowlist"
+	dropCollectionFromAllowList              = "drop_collection_from_allowlist"
+	replaceMetadata                          = "replace_metadata"
+	clearMetadata                            = "clear_metadata"
+	runSQL                                   = "run_sql"
+	bulkQuery                                = "bulk"
+	addComputedField                         = "add_computed_field"
+	dropComputedField                        = "drop_computed_field"
+)
+
+type tableMap struct {
+	name, schema string
+}
+
+type relationshipMap struct {
+	tableName, schemaName, name string
+}
+
+type permissionMap struct {
+	tableName, schemaName, permType, Role string
+}
+
+type computedFieldMap struct {
+	tableName, schemaName, name string
+}
+
+type queryInCollectionMap struct {
+	collectionName, queryName string
+}
+
+type tableSchema struct {
+	Name   string `json:"name" yaml:"name"`
+	Schema string `json:"schema" yaml:"schema"`
+}
+
+func (t *tableSchema) UnmarshalJSON(b []byte) error {
+	var table string
+	if err := json.Unmarshal(b, &table); err != nil {
+		var ts struct {
+			Name   string `json:"name"`
+			Schema string `json:"schema"`
+		}
+		if err := json.Unmarshal(b, &ts); err != nil {
+			return err
+		}
+		t.Name = ts.Name
+		t.Schema = ts.Schema
+		return nil
+	}
+	t.Name = table
+	t.Schema = "public"
+	return nil
+}
+
+type trackTableInput struct {
+	tableSchema
+	IsEnum bool `json:"is_enum" yaml:"is_enum"`
+}
+
+func (t *trackTableInput) UnmarshalJSON(b []byte) error {
+	type tmpT trackTableInput
+	var ts tmpT
+	if err := json.Unmarshal(b, &ts); err != nil {
+		return err
+	}
+	if ts.Schema == "" {
+		ts.Schema = "public"
+	}
+	*t = trackTableInput(ts)
+	return nil
+}
+
+type tableConfiguration struct {
+	CustomRootFields  map[string]string `json:"custom_root_fields" yaml:"custom_root_fields"`
+	CustomColumnNames map[string]string `json:"custom_column_names" yaml:"custom_column_names"`
+}
+
+type trackTableV2Input struct {
+	Table         tableSchema        `json:"table" yaml:"table"`
+	Configuration tableConfiguration `json:"configuration" yaml:"configuration"`
+}
+
+type setTableCustomFieldsV2Input struct {
+	Table tableSchema `json:"table" yaml:"table"`
+	tableConfiguration
+}
+
+type unTrackTableInput struct {
+	tableSchema
+}
+
+func (t *unTrackTableInput) UnmarshalJSON(b []byte) error {
+	type tmpT unTrackTableInput
+	var ts tmpT
+	if err := json.Unmarshal(b, &ts); err != nil {
+		return err
+	}
+	if ts.Schema == "" {
+		ts.Schema = "public"
+	}
+	*t = unTrackTableInput(ts)
+	return nil
+}
+
+type trackFunctionInput struct {
+	tableSchema
+}
+
+type unTrackFunctionInput struct {
+	Schema string `json:"schema" yaml:"schema"`
+	Name   string `json:"name" yaml:"name"`
+}
+
+type createObjectRelationshipInput struct {
+	Name    string      `json:"name" yaml:"name"`
+	Table   tableSchema `json:"table" yaml:"table"`
+	Using   interface{} `json:"using" yaml:"using"`
+	Comment *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type createArrayRelationshipInput struct {
+	Name    string      `json:"name" yaml:"name"`
+	Table   tableSchema `json:"table" yaml:"table"`
+	Using   interface{} `json:"using" yaml:"using"`
+	Comment *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type setRelationshipCommentInput struct {
+	Name    string      `json:"name" yaml:"name"`
+	Table   tableSchema `json:"table" yaml:"table"`
+	Comment *string     `json:"comment" yaml:"comment"`
+}
+
+type dropRelationshipInput struct {
+	RelationShip string      `json:"relationship" yaml:"relationship"`
+	Table        tableSchema `json:"table" yaml:"table"`
+}
+
+type createInsertPermissionInput struct {
+	Table      tableSchema `json:"table" yaml:"table"`
+	Role       string      `json:"role" yaml:"role"`
+	Permission interface{} `json:"permission" yaml:"permission"`
+	Comment    *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type dropInsertPermissionInput struct {
+	Table tableSchema `json:"table" yaml:"table"`
+	Role  string      `json:"role" yaml:"role"`
+}
+
+type createSelectPermissionInput struct {
+	Table      tableSchema `json:"table" yaml:"table"`
+	Role       string      `json:"role" yaml:"role"`
+	Permission interface{} `json:"permission" yaml:"permission"`
+	Comment    *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type dropSelectPermissionInput struct {
+	Table tableSchema `json:"table" yaml:"table"`
+	Role  string      `json:"role" yaml:"role"`
+}
+
+type createUpdatePermissionInput struct {
+	Table      tableSchema `json:"table" yaml:"table"`
+	Role       string      `json:"role" yaml:"role"`
+	Permission interface{} `json:"permission" yaml:"permission"`
+	Comment    *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type dropUpdatePermissionInput struct {
+	Table tableSchema `json:"table" yaml:"table"`
+	Role  string      `json:"role" yaml:"role"`
+}
+
+type createDeletePermissionInput struct {
+	Table      tableSchema `json:"table" yaml:"table"`
+	Role       string      `json:"role" yaml:"role"`
+	Permission interface{} `json:"permission" yaml:"permission"`
+	Comment    *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type dropDeletePermissionInput struct {
+	Table tableSchema `json:"table" yaml:"table"`
+	Role  string      `json:"role" yaml:"role"`
+}
+
+type setPermissionCommentInput struct {
+	Table   tableSchema `json:"table" yaml:"table"`
+	Role    string      `json:"role" yaml:"role"`
+	Type    string      `json:"type" yaml:"type"`
+	Comment *string     `json:"comment" yaml:"comment"`
+}
+
+type createEventTriggerInput struct {
+	Name           string                            `json:"name" yaml:"name"`
+	Table          tableSchema                       `json:"table" yaml:"table"`
+	Webhook        string                            `json:"webhook,omitempty" yaml:"webhook,omitempty"`
+	WebhookFromEnv string                            `json:"webhook_from_env,omitempty" yaml:"webhook_from_env,omitempty"`
+	Definition     *createEventTriggerOperationInput `json:"definition,omitempty" yaml:"definition,omitempty"`
+	Headers        interface{}                       `json:"headers" yaml:"headers"`
+	Replace        bool                              `json:"replace" yaml:"replace"`
+
+	createEventTriggerOperationInput
+}
+
+type createEventTriggerOperationInput struct {
+	Insert interface{} `json:"insert,omitempty" yaml:"insert,omitempty"`
+	Update interface{} `json:"update,omitempty" yaml:"update,omitempty"`
+	Delete interface{} `json:"delete,omitempty" yaml:"delete,omitempty"`
+}
+
+func (c *createEventTriggerInput) MarshalJSON() ([]byte, error) {
+	if c.Definition != nil {
+		c.Insert = c.Definition.Insert
+		c.Update = c.Definition.Update
+		c.Delete = c.Definition.Delete
+		c.Definition = nil
+	}
+	return json.Marshal(&struct {
+		Name           string      `json:"name" yaml:"name"`
+		Table          tableSchema `json:"table" yaml:"table"`
+		Webhook        string      `json:"webhook,omitempty" yaml:"webhook,omitempty"`
+		WebhookFromEnv string      `json:"webhook_from_env,omitempty" yaml:"webhook_from_env,omitempty"`
+		Headers        interface{} `json:"headers" yaml:"headers"`
+		Replace        bool        `json:"replace" yaml:"replace"`
+		Insert         interface{} `json:"insert,omitempty" yaml:"insert,omitempty"`
+		Update         interface{} `json:"update,omitempty" yaml:"update,omitempty"`
+		Delete         interface{} `json:"delete,omitempty" yaml:"delete,omitempty"`
+	}{
+		Name:           c.Name,
+		Table:          c.Table,
+		Webhook:        c.Webhook,
+		WebhookFromEnv: c.WebhookFromEnv,
+		Headers:        c.Headers,
+		Replace:        c.Replace,
+		Insert:         c.Insert,
+		Update:         c.Update,
+		Delete:         c.Delete,
+	})
+}
+
+type deleteEventTriggerInput struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+type addRemoteSchemaInput struct {
+	Name       string      `json:"name" yaml:"name"`
+	Definition interface{} `json:"definition" yaml:"definition"`
+	Comment    *string     `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+type removeRemoteSchemaInput struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+type collectionQuery struct {
+	Name  string `json:"name" yaml:"name"`
+	Query string `json:"query" yaml:"query"`
+}
+
+type createQueryCollectionInput struct {
+	Name       string  `json:"name" yaml:"name"`
+	Comment    *string `json:"comment,omitempty" yaml:"comment,omitempty"`
+	Definition struct {
+		Queries []collectionQuery `json:"queries" yaml:"queries"`
+	} `json:"definition" yaml:"definition"`
+}
+
+type dropQueryCollectionInput struct {
+	Collection string `json:"name" yaml:"name"`
+	Cascade    bool   `json:"cascade" yaml:"cascade"`
+}
+
+type addQueryToCollectionInput struct {
+	CollectionName string `json:"collection_name" yaml:"collection_name"`
+	QueryName      string `json:"query_name" yaml:"query_name"`
+	Query          string `json:"query" yaml:"query"`
+}
+
+type dropQueryFromCollectionInput struct {
+	CollectionName string `json:"collection_name" yaml:"collection_name"`
+	QueryName      string `json:"query_name" yaml:"query_name"`
+}
+
+type addCollectionToAllowListInput struct {
+	Collection string `json:"collection" yaml:"collection"`
+}
+
+type dropCollectionFromAllowListInput struct {
+	Collection string `json:"collection" yaml:"collection"`
+}
+
+type addComputedFieldInput struct {
+	Table      tableSchema `json:"table" yaml:"table"`
+	Name       string      `json:"name" yaml:"name"`
+	Definition interface{} `json:"definition" yaml:"definition"`
+}
+
+type dropComputedFieldInput struct {
+	Table   tableSchema `json:"table" yaml:"table"`
+	Name    string      `json:"name" yaml:"name"`
+	Cascade bool        `json:"cascade" yaml:"cascade"`
+	Comment string      `json:"comment" yaml:"comment"`
+}
+
+type clearMetadataInput struct {
+}
+
+type replaceMetadataInput struct {
+	Tables []struct {
+		Table               tableSchema                      `json:"table" yaml:"table"`
+		ArrayRelationships  []*createArrayRelationshipInput  `json:"array_relationships" yaml:"array_relationships"`
+		ObjectRelationships []*createObjectRelationshipInput `json:"object_relationships" yaml:"object_relationships"`
+		InsertPermissions   []*createInsertPermissionInput   `json:"insert_permissions" yaml:"insert_permissions"`
+		SelectPermissions   []*createSelectPermissionInput   `json:"select_permissions" yaml:"select_permissions"`
+		UpdatePermissions   []*createUpdatePermissionInput   `json:"update_permissions" yaml:"update_permissions"`
+		DeletePermissions   []*createDeletePermissionInput   `json:"delete_permissions" yaml:"delete_permissions"`
+		EventTriggers       []*createEventTriggerInput       `json:"event_triggers" yaml:"event_triggers"`
+		ComputedFields      []*addComputedFieldInput         `json:"computed_fields" yaml:"computed_fields"`
+		Configuration       *tableConfiguration              `json:"configuration" yaml:"configuration"`
+	} `json:"tables" yaml:"tables"`
+	Functions        []*trackFunctionInput            `json:"functions" yaml:"functions"`
+	QueryCollections []*createQueryCollectionInput    `json:"query_collections" yaml:"query_collections"`
+	AllowList        []*addCollectionToAllowListInput `json:"allowlist" yaml:"allowlist"`
+	RemoteSchemas    []*addRemoteSchemaInput          `json:"remote_schemas" yaml:"remote_schemas"`
+}
+
+func (rmi *replaceMetadataInput) convertToMetadataActions(l *database.CustomList) {
+	// track tables
+	for _, table := range rmi.Tables {
+		if table.Configuration == nil {
+			t := &trackTableInput{
+				tableSchema: tableSchema{
+					Name:   table.Table.Name,
+					Schema: table.Table.Schema,
+				},
+			}
+			l.PushBack(t)
+		} else {
+			t := &trackTableV2Input{
+				Table: tableSchema{
+					Name:   table.Table.Name,
+					Schema: table.Table.Schema,
+				},
+				Configuration: *table.Configuration,
+			}
+			l.PushBack(t)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, objRel := range table.ObjectRelationships {
+			objRel.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(objRel)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, arrayRel := range table.ArrayRelationships {
+			arrayRel.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(arrayRel)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, insertPerm := range table.InsertPermissions {
+			insertPerm.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(insertPerm)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, selectPerm := range table.SelectPermissions {
+			selectPerm.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(selectPerm)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, updatePerm := range table.UpdatePermissions {
+			updatePerm.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(updatePerm)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, deletePerm := range table.DeletePermissions {
+			deletePerm.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(deletePerm)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, et := range table.EventTriggers {
+			et.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(et)
+		}
+	}
+
+	for _, table := range rmi.Tables {
+		for _, cf := range table.ComputedFields {
+			cf.Table = tableSchema{
+				table.Table.Name,
+				table.Table.Schema,
+			}
+			l.PushBack(cf)
+		}
+	}
+	// track functions
+	for _, function := range rmi.Functions {
+		l.PushBack(function)
+	}
+
+	// track query collections
+	for _, qc := range rmi.QueryCollections {
+		l.PushBack(qc)
+	}
+
+	// track allow list
+	for _, al := range rmi.AllowList {
+		l.PushBack(al)
+	}
+
+	// track remote schemas
+	for _, rs := range rmi.RemoteSchemas {
+		l.PushBack(rs)
+	}
+}
+
+type runSQLInput struct {
+	SQL string `json:"sql" yaml:"sql"`
+}
+
+type tableConfig struct {
+	name, schema string
+	transition.Transition
+}
+
+type relationshipConfig struct {
+	tableName, schemaName, name string
+	transition.Transition
+}
+
+type permissionConfig struct {
+	tableName, schemaName, permType, role string
+	transition.Transition
+}
+
+type computedFieldConfig struct {
+	tableName, schemaName, name string
+	transition.Transition
+}
+
+type functionConfig struct {
+	name, schema string
+	transition.Transition
+}
+
+type eventTriggerConfig struct {
+	name string
+	transition.Transition
+}
+
+type remoteSchemaConfig struct {
+	name string
+	transition.Transition
+}
+
+type queryCollectionConfig struct {
+	name      string
+	allowList bool
+	transition.Transition
+}
+
+type queryInCollectionConfig struct {
+	collectionName string
+	queryName      string
+	transition.Transition
+}
+
+type allowListConfig struct {
+	collection string
+	transition.Transition
 }

--- a/cli/migrate/database/types.go
+++ b/cli/migrate/database/types.go
@@ -1,0 +1,33 @@
+package database
+
+import (
+	"container/list"
+
+	"github.com/ahmetb/go-linq"
+)
+
+type CustomList struct {
+	*list.List
+}
+
+func (c *CustomList) Iterate() linq.Iterator {
+	length := c.Len()
+	var prevElem *list.Element
+	i := 0
+	return func() (item interface{}, ok bool) {
+		if length == 0 {
+			return
+		}
+
+		if i == 0 {
+			prevElem = c.Front()
+			i++
+		} else {
+			prevElem = prevElem.Next()
+			if prevElem == nil {
+				return
+			}
+		}
+		return prevElem, true
+	}
+}

--- a/cli/migrate/source/file/file.go
+++ b/cli/migrate/source/file/file.go
@@ -80,17 +80,50 @@ func (f *File) Close() error {
 
 func (f *File) Scan() error {
 	f.migrations = source.NewMigrations()
-	files, err := ioutil.ReadDir(f.path)
+	folders, err := ioutil.ReadDir(f.path)
 	if err != nil {
 		return err
 	}
 
-	for _, fi := range files {
-		if !fi.IsDir() {
-			m, err := source.DefaultParse(fi.Name(), f.path)
+	for _, fo := range folders {
+		if fo.IsDir() {
+			// v2 migrate
+			dirName := fo.Name()
+			dirPath := filepath.Join(f.path, dirName)
+			files, err := ioutil.ReadDir(dirPath)
+			if err != nil {
+				return err
+			}
+
+			for _, fi := range files {
+				if fi.IsDir() {
+					continue
+				}
+				fileName := fmt.Sprintf("%s.%s", dirName, fi.Name())
+				m, err := source.DefaultParse(fileName)
+				if err != nil {
+					continue // ignore files that we can't parse
+				}
+				m.Raw = filepath.Join(dirName, fi.Name())
+				ok, err := source.IsEmptyFile(m, f.path)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+				err = f.migrations.Append(m)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			// v1 migrate
+			m, err := source.DefaultParse(fo.Name())
 			if err != nil {
 				continue // ignore files that we can't parse
 			}
+			m.Raw = fo.Name()
 			ok, err := source.IsEmptyFile(m, f.path)
 			if err != nil {
 				return err

--- a/cli/migrate/source/parse.go
+++ b/cli/migrate/source/parse.go
@@ -26,7 +26,7 @@ var (
 var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)
 
 // Parse returns Migration for matching Regex pattern.
-func Parse(raw string, directory string) (*Migration, error) {
+func Parse(raw string) (*Migration, error) {
 	var direction Direction
 	m := Regex.FindStringSubmatch(raw)
 	if len(m) == 5 {
@@ -58,7 +58,6 @@ func Parse(raw string, directory string) (*Migration, error) {
 			Version:    versionUint64,
 			Identifier: m[2],
 			Direction:  direction,
-			Raw:        raw,
 		}, nil
 	}
 	return nil, ErrParse

--- a/cli/migrate/status.go
+++ b/cli/migrate/status.go
@@ -6,18 +6,18 @@ import (
 
 type MigrationStatus struct {
 	// Version is the version of this migration.
-	Version uint64
+	Version uint64 `json:"-"`
 
 	// Check if the migration is applied on the cluster
-	IsApplied bool
+	IsApplied bool `json:"database_status"`
 
 	// Check if the migration is present on the local.
-	IsPresent bool
+	IsPresent bool `json:"source_status"`
 }
 
 type Status struct {
-	Index      uint64Slice
-	Migrations map[uint64]*MigrationStatus
+	Index      uint64Slice                 `json:"migrations"`
+	Migrations map[uint64]*MigrationStatus `json:"status"`
 }
 
 func NewStatus() *Status {

--- a/event-triggers.md
+++ b/event-triggers.md
@@ -69,7 +69,7 @@ Trigger push notifications and emails based on database events. Try the demo and
 
 * [Watch demo](https://www.youtube.com/watch?v=nuSHkzE2-zo)
 * [Try it out](https://serverless-push.demo.hasura.app/)
-* [Tutorial](community/examples/serverless-push)
+* [Tutorial](community/sample-apps/serverless-push)
 
 
 <!--
@@ -89,7 +89,7 @@ Transform and load data into external data-stores. Check out this demo and tutor
 
 * [Watch demo](https://youtu.be/kWVEBWdEVAA)
 * [Try it out](https://serverless-etl.demo.hasura.app/)
-* [Tutorial](community/examples/serverless-etl)
+* [Tutorial](community/sample-apps/serverless-etl)
 
 ### Building reactive UX for your async backend with realtime GraphQL
 

--- a/install-manifests/azure-container-with-pg/azuredeploy.json
+++ b/install-manifests/azure-container-with-pg/azuredeploy.json
@@ -97,7 +97,7 @@
     "firewallRuleName": "allow-all-azure-firewall-rule",
     "containerGroupName": "[concat(parameters('name'), '-container-group')]",
     "containerName": "hasura-graphql-engine",
-    "containerImage": "hasura/graphql-engine:v1.0.0-beta.8"
+    "containerImage": "hasura/graphql-engine:v1.0.0-beta.9"
   },
   "resources": [
     {

--- a/install-manifests/azure-container/azuredeploy.json
+++ b/install-manifests/azure-container/azuredeploy.json
@@ -55,7 +55,7 @@
     "dbName": "[parameters('postgresDatabaseName')]",
     "containerGroupName": "[concat(parameters('name'), '-container-group')]",
     "containerName": "hasura-graphql-engine",
-    "containerImage": "hasura/graphql-engine:v1.0.0-beta.8"
+    "containerImage": "hasura/graphql-engine:v1.0.0-beta.9"
   },
   "resources": [
     {

--- a/install-manifests/docker-compose-https/docker-compose.yaml
+++ b/install-manifests/docker-compose-https/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
     - db_data:/var/lib/postgresql/data
   graphql-engine:
-    image: hasura/graphql-engine:v1.0.0-beta.8
+    image: hasura/graphql-engine:v1.0.0-beta.9
     depends_on:
     - "postgres"
     restart: always

--- a/install-manifests/docker-compose-pgadmin/docker-compose.yaml
+++ b/install-manifests/docker-compose-pgadmin/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: pgadmin@example.com
       PGADMIN_DEFAULT_PASSWORD: admin
   graphql-engine:
-    image: hasura/graphql-engine:v1.0.0-beta.8
+    image: hasura/graphql-engine:v1.0.0-beta.9
     ports:
     - "8080:8080"
     depends_on:

--- a/install-manifests/docker-compose-postgis/docker-compose.yaml
+++ b/install-manifests/docker-compose-postgis/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
     - db_data:/var/lib/postgresql/data
   graphql-engine:
-    image: hasura/graphql-engine:v1.0.0-beta.8
+    image: hasura/graphql-engine:v1.0.0-beta.9
     ports:
     - "8080:8080"
     depends_on:

--- a/install-manifests/docker-compose/docker-compose.yaml
+++ b/install-manifests/docker-compose/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
     - db_data:/var/lib/postgresql/data
   graphql-engine:
-    image: hasura/graphql-engine:v1.0.0-beta.8
+    image: hasura/graphql-engine:v1.0.0-beta.9
     ports:
     - "8080:8080"
     depends_on:

--- a/install-manifests/docker-run/docker-run.sh
+++ b/install-manifests/docker-run/docker-run.sh
@@ -2,4 +2,4 @@
 docker run -d -p 8080:8080 \
        -e HASURA_GRAPHQL_DATABASE_URL=postgres://username:password@hostname:port/dbname \
        -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
-       hasura/graphql-engine:v1.0.0-beta.8
+       hasura/graphql-engine:v1.0.0-beta.9

--- a/install-manifests/google-cloud-k8s-sql/deployment.yaml
+++ b/install-manifests/google-cloud-k8s-sql/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: graphql-engine
-          image: hasura/graphql-engine:v1.0.0-beta.8
+          image: hasura/graphql-engine:v1.0.0-beta.9
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/install-manifests/kubernetes/deployment.yaml
+++ b/install-manifests/kubernetes/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: hasura
     spec:
       containers:
-      - image: hasura/graphql-engine:v1.0.0-beta.8
+      - image: hasura/graphql-engine:v1.0.0-beta.9
         imagePullPolicy: IfNotPresent
         name: hasura
         env:

--- a/scripts/cli-migrations/Dockerfile
+++ b/scripts/cli-migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v1.0.0-beta.8
+FROM hasura/graphql-engine:v1.0.0-beta.9
 
 # set an env var to let the cli know that
 # it is running in server environment

--- a/server/tests-py/queries/graphql_mutation/delete/constraints/author_foreign_key_violation.yaml
+++ b/server/tests-py/queries/graphql_mutation/delete/constraints/author_foreign_key_violation.yaml
@@ -9,6 +9,7 @@ query:
       }
     } 
 response:
+  data: null
   errors:
   - extensions:
       code: constraint-violation

--- a/server/tests-py/queries/graphql_mutation/insert/constraints/address_not_null_constraint_error.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/constraints/address_not_null_constraint_error.yaml
@@ -14,6 +14,7 @@ query:
     } 
 
 response:
+  data: null
   errors:
   - extensions:
       code: constraint-violation

--- a/server/tests-py/queries/graphql_mutation/insert/constraints/author_unique_constraint_error.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/constraints/author_unique_constraint_error.yaml
@@ -21,6 +21,7 @@ query:
       }
     } 
 response:
+  data: null
   errors:
   - extensions:
       code: constraint-violation

--- a/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_author_author_id_fail.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/articles_with_author_author_id_fail.yaml
@@ -44,6 +44,7 @@ query:
    }
 
 response:
+  data: null
   errors:
   - extensions:
       code: validation-failed

--- a/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_author_id_fail.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/nested/author_with_articles_author_id_fail.yaml
@@ -2,6 +2,7 @@ description: Insert author and it's articles via nested mutation (Error)
 url: /v1/graphql
 status: 200
 response:
+  data: null
   errors:
   - extensions:
       code: validation-failed

--- a/server/tests-py/queries/graphql_mutation/insert/permissions/developer_insert_has_keys_any_fail.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/permissions/developer_insert_has_keys_any_fail.yaml
@@ -1,7 +1,8 @@
 description: Inserts computer specs with atleast one of the required keys
-url: /v1alpha1/graphql
-status: 400
+url: /v1/graphql
+status: 200
 response:
+  data: null
   errors:
   - extensions:
       path: $.selectionSet.insert_computer.args.objects

--- a/server/tests-py/queries/graphql_mutation/insert/permissions/insert_article_arr_sess_var_editors_err_not_allowed_user_id.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/permissions/insert_article_arr_sess_var_editors_err_not_allowed_user_id.yaml
@@ -1,10 +1,11 @@
 description: Editor inserts article data for a not allowed user-id
-url: /v1alpha1/graphql
-status: 400
+url: /v1/graphql
+status: 200
 headers:
   X-Hasura-Role: editor
   X-Hasura-Allowed-User-Ids: '{1,3,4}'
 response:
+  data: null
   errors:
   - extensions:
       path: $.selectionSet.insert_article.args.objects

--- a/server/tests-py/queries/graphql_mutation/insert/permissions/seller_insert_computer_has_keys_all_fail.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/permissions/seller_insert_computer_has_keys_all_fail.yaml
@@ -1,7 +1,8 @@
 description: Inserts computer specs without all the required keys (error)
-url: /v1alpha1/graphql
-status: 400
+url: /v1/graphql
+status: 200
 response:
+  data: null
   errors:
   - extensions:
       path: $.selectionSet.insert_computer.args.objects

--- a/server/tests-py/queries/graphql_mutation/insert/permissions/user_insert_account_fail.yaml
+++ b/server/tests-py/queries/graphql_mutation/insert/permissions/user_insert_account_fail.yaml
@@ -5,6 +5,7 @@ headers:
   X-Hasura-Role: user
   X-Hasura-User-Id: '1'
 response:
+  data: null
   errors:
   - extensions:
       path: "$.selectionSet.insert_account.args.objects"

--- a/server/tests-py/queries/graphql_query/basic/select_query_invalid_escape_sequence.yaml
+++ b/server/tests-py/queries/graphql_query/basic/select_query_invalid_escape_sequence.yaml
@@ -2,6 +2,7 @@ description: GraphQL query with invalid escape sequence
 url: /v1/graphql
 status: 200
 response:
+  data: null
   errors:
   - extensions:
       code: bad-request

--- a/server/tests-py/requirements-top-level.txt
+++ b/server/tests-py/requirements-top-level.txt
@@ -8,5 +8,5 @@ websocket-client
 pyjwt >= 1.5.3
 jsondiff
 cryptography
-graphene
+graphene==3.0.dev20190817210753
 brotlipy

--- a/server/tests-py/requirements.txt
+++ b/server/tests-py/requirements.txt
@@ -1,16 +1,17 @@
-aniso8601==3.0.2
+aniso8601==7.0.0
 apipkg==1.5
 asn1crypto==0.24.0
 atomicwrites==1.3.0
 attrs==19.1.0
+brotlipy==0.7.0
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
 cryptography==2.7
 execnet==1.6.0
-graphene==2.1.3
-graphql-core==2.1
-graphql-relay==0.4.5
+graphene==3.0.dev20190817210753
+graphql-core==3.0.0b1
+graphql-relay==3.0.0a1
 idna==2.8
 importlib-metadata==0.17
 jsondiff==1.1.2
@@ -33,4 +34,3 @@ urllib3==1.25.3
 wcwidth==0.1.7
 websocket-client==0.56.0
 zipp==0.5.1
-brotlipy==0.7.0

--- a/server/tests-py/test_allowlist_queries.py
+++ b/server/tests-py/test_allowlist_queries.py
@@ -5,7 +5,7 @@ from validate import check_query_f
 from super_classes import DefaultTestSelectQueries
 
 @pytest.mark.skipif(not pytest.config.getoption("--test-allowlist-queries"),
-                    reason="flag --test-allowlist-queries is not set. Cannot runt tests for allowlist queries")
+                    reason="flag --test-allowlist-queries is not set. Cannot run tests for allowlist queries")
 @pytest.mark.parametrize("transport", ['http','websocket'])
 class TestAllowlistQueries(DefaultTestSelectQueries):
 

--- a/server/tests-py/test_schema_stitching.py
+++ b/server/tests-py/test_schema_stitching.py
@@ -350,7 +350,7 @@ class TestRemoteSchemaQueriesOverWebsocket:
             assert ev['type'] == 'data' and ev['id'] == query_id, ev
             assert 'errors' in ev['payload']
             assert ev['payload']['errors'][0]['message'] == \
-                'Cannot query field "blah" on type "User".'
+                "Cannot query field 'blah' on type 'User'."
         finally:
             ws_client.stop(query_id)
 

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -672,3 +672,15 @@ class TestComputedFields(DefaultTestQueries):
 
     def test_run_sql(self, hge_ctx):
         check_query_f(hge_ctx, self.dir() + '/run_sql.yaml')
+
+
+class TestTrackFunctions(DefaultTestQueries):
+    @classmethod
+    def dir(cls):
+        return 'queries/graphql_query/functions'
+
+    def test_alter_function_error(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/alter_function_error.yaml')
+
+    def test_overloading_function_error(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + '/overloading_function_error.yaml')


### PR DESCRIPTION
The main changes are as follows

1) The beta version of graphene v3 is used so that we get the latest graphql-core. Now the graphql parse errors will not happen for tests.
2) Python-3.7 is used for pytests in circleci (mainly due to using graphene v3).
3) Tests on HTTP do not return `{data:null}` if the query fails after validation. These test will be `XFAIL`ed if the only error is missing {data:null} with a reference to the corresponding issue (https://github.com/hasura/graphql-engine-internal/issues/301)